### PR TITLE
Feat/last 24 hours analysis

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wernerthiago/teo",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Test Execution Optimizer",
   "main": "src/cli/index.js",
   "type": "module",

--- a/src/analyzers/git-analyzer.js
+++ b/src/analyzers/git-analyzer.js
@@ -569,6 +569,27 @@ export class GitDiffAnalyzer {
       throw error
     }
   }
+
+  /**
+   * Get last commit within the 24 hours ago
+   */
+  async getLastCommitWithin24Hours() {
+    try {
+      const since = new Date(Date.now() - 24 * 60 * 60 * 1000)
+      const sinceIso = since.toISOString()
+      const log = await this.git.log({ '--before': sinceIso, n: 1 })
+      if (log.total > 0) {
+        return log.latest.hash
+      } else {
+        // If no commit before 24h ago, return the first commit in history
+        const allLog = await this.git.log({ n: 1, '--reverse': null })
+        return allLog.latest ? allLog.latest.hash : null
+      }
+    } catch (error) {
+      logger.error('Failed to get last commit within 24 hours', { error: error.message })
+      throw error
+    }
+  }
 }
 
 export default GitDiffAnalyzer

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -104,23 +104,22 @@ program
     if (globalOpts.quiet && !globalOpts.verbose) {
       logger.level = 'quiet'
     }
-
-    // Validation: Either --last-24h or both --base and --head must be provided, but not both
-    if (options.last24h) {
-      if (options.base || options.head) {
-        spinner.fail('Cannot use --last-24h with --base or --head. Use either --last-24h or both --base and --head.')
-        process.exit(1)
-      }
-    } else {
-      if (!options.base || !options.head) {
-        spinner.fail('You must provide both --base and --head, or use --last-24h.')
-        process.exit(1)
-      }
-    }
     
     const spinner = ora('Analyzing code changes...', { isSilent: globalOpts.quiet }).start()
-    
+
     try {
+      // Validation: Either --last-24h or both --base and --head must be provided, but not both
+      if (options.last24h) {
+        if (options.base || options.head) {
+          spinner.fail('Cannot use --last-24h with --base or --head. Use either --last-24h or both --base and --head.')
+          process.exit(1)
+        }
+      } else {
+        if (!options.base || !options.head) {
+          spinner.fail('You must provide both --base and --head, or use --last-24h.')
+          process.exit(1)
+        }
+      }
       // Load configuration
       const config = await TEOConfig.fromFile(globalOpts.config)
       const engine = await TEOEngine.create(config)

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -82,8 +82,9 @@ program
 program
   .command('analyze')
   .description('Analyze code changes and select relevant tests')
-  .requiredOption('--base <ref>', 'Base git reference (e.g., HEAD~1, main)')
-  .requiredOption('--head <ref>', 'Head git reference (e.g., HEAD, feature-branch)')
+  .option('--base <ref>', 'Base git reference', false)
+  .option('--head <ref>', 'Head git reference', false)
+  .option('--last-24h', 'Gets the difference between the last commit and the last 24h commit', false)
   .option('--framework <name>', 'Test framework to use', 'playwright')
   .option('--output <format>', 'Output format (paths|script|json|table|playwright-args)', 'table')
   .option('--no-ai', 'Disable AI-enhanced analysis')
@@ -100,6 +101,19 @@ program
     if (globalOpts.quiet && !globalOpts.verbose) {
       logger.level = 'quiet'
     }
+
+    // Validation: Either --last-24h or both --base and --head must be provided, but not both
+    if (options.last24h) {
+      if (options.base || options.head) {
+        spinner.fail('Cannot use --last-24h with --base or --head. Use either --last-24h or both --base and --head.')
+        process.exit(1)
+      }
+    } else {
+      if (!options.base || !options.head) {
+        spinner.fail('You must provide both --base and --head, or use --last-24h.')
+        process.exit(1)
+      }
+    }
     
     const spinner = ora('Analyzing code changes...', { isSilent: globalOpts.quiet }).start()
     
@@ -109,12 +123,24 @@ program
       const engine = await TEOEngine.create(config)
       
       // Perform analysis
-      const result = await engine.analyze(options.base, options.head, {
+      let analyzeOptions = {
+        last24h: options.last24h,
         useAI: options.ai,
         aiProvider: options.aiProvider,
         framework: options.framework,
         confidenceThreshold: options.confidence
-      })
+      }
+
+      let base = options.base
+      let head = options.head
+
+      if (options.last24h) {
+        // Let engine handle last24h logic, base/head may be undefined
+        base = undefined
+        head = undefined
+      }
+
+      const result = await engine.analyze(base, head, analyzeOptions)
       
       spinner.succeed('Analysis completed')
       
@@ -197,37 +223,63 @@ program
 program
   .command('script')
   .description('Generate executable test script')
-  .requiredOption('--base <ref>', 'Base git reference')
-  .requiredOption('--head <ref>', 'Head git reference')
+  .option('--base <ref>', 'Base git reference')
+  .option('--head <ref>', 'Head git reference')
+  .option('--last-24h', 'Gets the difference between the last commit and the last 24h commit', false)
   .option('--framework <name>', 'Test framework to use', 'playwright')
   .option('--output <file>', 'Output script file', 'run-selected-tests.sh')
   .option('--no-ai', 'Disable AI-enhanced analysis')
   .action(async (options) => {
     const globalOpts = program.opts()
     const spinner = ora('Generating test execution script...', { isSilent: globalOpts.quiet }).start()
-    
+
     try {
+      // Validation: Either --last-24h or both --base and --head must be provided, but not both
+      if (options.last24h) {
+        if (options.base || options.head) {
+          spinner.fail('Cannot use --last-24h with --base or --head. Use either --last-24h or both --base and --head.')
+          process.exit(1)
+        }
+      } else {
+        if (!options.base || !options.head) {
+          spinner.fail('You must provide both --base and --head, or use --last-24h.')
+          process.exit(1)
+        }
+      }
+
       const config = await TEOConfig.fromFile(globalOpts.config)
       const engine = await TEOEngine.create(config)
-      
-      const result = await engine.analyze(options.base, options.head, {
+
+      let analyzeOptions = {
         useAI: options.ai,
-        framework: options.framework
-      })
-      
+        framework: options.framework,
+        last24h: options.last24h
+      }
+
+      let base = options.base
+      let head = options.head
+
+      if (options.last24h) {
+        // Let engine handle last24h logic, base/head may be undefined
+        base = undefined
+        head = undefined
+      }
+
+      const result = await engine.analyze(base, head, analyzeOptions)
+
       const script = engine.generateOutput(result, 'script')
       await fs.writeFile(options.output, script)
       await fs.chmod(options.output, 0o755) // Make executable
-      
+
       spinner.succeed(`Executable script generated: ${options.output}`)
-      
+
       console.log(chalk.green('\n✅ Test execution script created!'))
       console.log(chalk.blue(`\n🚀 Run with: ./${options.output}`))
-      
+
       if (!globalOpts.quiet) {
         displaySummary(result)
       }
-      
+
     } catch (error) {
       spinner.fail('Script generation failed')
       console.error(chalk.red('Error:'), error.message)

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -15,14 +15,17 @@ import path from 'path'
 import TEOEngine from '../core/engine.js'
 import TEOConfig from '../core/config.js'
 import logger from '../core/logger.js'
+import pkg from '../../package.json' assert { type: 'json' }
 
 const program = new Command()
 
 // Global options
+// Read version from package.json
+
 program
   .name('teo')
   .description('Test Execution Optimizer - Intelligent test selection for modern development')
-  .version('2.0.0')
+  .version(pkg.version)
   .option('-v, --verbose', 'Enable verbose logging')
   .option('-q, --quiet', 'Suppress non-essential output')
   .option('--config <path>', 'Path to configuration file', 'teo-config.yaml')

--- a/src/core/engine.js
+++ b/src/core/engine.js
@@ -84,9 +84,9 @@ export class TEOEngine {
       logger.info('Starting TEO analysis', { baseRef, headRef, options })
       
       // Step 1: Analyze git diff
-      if (!baseRef && !headRef && !options.last24h) {
-        logger.error('Base and head references must be provided, or use last24h option');
-        throw new Error('Base and head references must be provided, or use last24h option');
+      if (!options.last24h && (!baseRef || !headRef)) {
+        logger.error('Both baseRef and headRef must be provided when last24h option is not set');
+        throw new Error('Both baseRef and headRef must be provided when last24h option is not set');
       }
       if (options.last24h) {
         logger.info('Using last 24 hours commit for analysis');


### PR DESCRIPTION
This pull request introduces a new feature to analyze code changes based on commits within the last 24 hours (`--last-24h`), along with adjustments to the CLI and internal logic to support this functionality. It also updates the package version to `1.1.1` and dynamically retrieves the version from `package.json`. Below are the most significant changes:

### New Feature: `--last-24h` Option for Commit Analysis
* Added a new method `getLastCommitWithin24Hours` in `GitDiffAnalyzer` to fetch the last commit within the past 24 hours or the first commit in history if no recent commits exist.
* Updated `TEOEngine.analyze` to support the `--last-24h` option, allowing analysis based on the last commit and the most recent commit within 24 hours. Includes validation to ensure proper usage of `baseRef`, `headRef`, and `last24h`.

### CLI Enhancements
* Added the `--last-24h` option to the `analyze` and `script` commands in `src/cli/index.js`. Updated validation logic to enforce mutual exclusivity between `--last-24h` and `--base`/`--head`. [[1]](diffhunk://#diff-f00e7c78fa83a1316c2844a481cc2eeda7c7c2c4f958d39e9e457ddbc6b5c20fL85-R90) [[2]](diffhunk://#diff-f00e7c78fa83a1316c2844a481cc2eeda7c7c2c4f958d39e9e457ddbc6b5c20fL200-R231) [[3]](diffhunk://#diff-f00e7c78fa83a1316c2844a481cc2eeda7c7c2c4f958d39e9e457ddbc6b5c20fR240-R271)
* Updated the `analyze` and `script` commands to handle `--last-24h` logic by passing appropriate options to the `TEOEngine`. [[1]](diffhunk://#diff-f00e7c78fa83a1316c2844a481cc2eeda7c7c2c4f958d39e9e457ddbc6b5c20fL112-R146) [[2]](diffhunk://#diff-f00e7c78fa83a1316c2844a481cc2eeda7c7c2c4f958d39e9e457ddbc6b5c20fR240-R271)

### Version Management
* Modified `src/cli/index.js` to dynamically read the version from `package.json` instead of hardcoding it, ensuring consistency across the CLI and package metadata.
* Updated the package version in `package.json` from `1.1.0` to `1.1.1`.